### PR TITLE
Add fix for ant package issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ sudo apt-get install default-jre default-jdk ant
 
 Bada-bing!
 
+If running ```learn test``` gives you a long error ending in "This is not a bug; it is a configuration problem", you may need to additionally install the package ```ant-optional``` (if your package manager is apt-get) or ```ant-junit``` (if your package manager is yum):
+
+```bash
+sudo apt-get install ant-optional
+```
 
 ## Resources
 


### PR DESCRIPTION
On a Linux Mint system, whenever I tried to run "learn test," I would continually get a failing JUnit build with the error message "the class org.apache.tools.ant.taskdefs.optional.junit.JUnitTask was not found". The solution was to install the ant-optional package, [which also fixed the problem for many StackOverflow users](http://stackoverflow.com/questions/6568634/how-to-solve-cause-the-class-org-apache-tools-ant-taskdefs-optional-junit-juni).